### PR TITLE
Optional %headers and $content params support.

### DIFF
--- a/t/custom-headers-and-content.t
+++ b/t/custom-headers-and-content.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+use LWP::Simple;
+
+# This test uses live JSON-RPC demo service located at:
+# http://jsolait.net/services/test.jsonrpc
+
+my $host= 'http://jsolait.net/services/test.jsonrpc';
+my %headers = ( 'Content-Type' => 'application/json' );
+my $content = '{"method":"echo","params":["Hello from Perl6"],"id":1}';
+
+my $html = LWP::Simple.get($host, %headers, $content);
+
+# return line should looks like
+# {"id": 1, "result": "Hello from Perl6", "error": null}
+
+ok(
+    $html.match('Hello from Perl6'),
+    'call to JSON-RPC service using headers and content params'
+);
+
+done;
+


### PR DESCRIPTION
Added HTTP Request optional %headers and $content params to get() method, so various *RPC clients can be implemented using this module.

Confirmed by new test that calls live JSON-PRC demo service.
