### PR TITLE
Update lib/LWP/Simple.pm

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -154,7 +154,9 @@ method make_request (
     $sock.send($req_str);
 
     # a bit crude w respect to err handling and blocking but ok for now
-    my $resp = ~ gather for $sock.recv() xx * { .bytes ?? take $_ !! last };
+    my $resp = join '', gather loop {
+        my $s = $sock.recv; last unless $s.chars; take $s
+    };
     $sock.close();
 
     my ($status, $resp_headers, $resp_content) = self.parse_response($resp);


### PR DESCRIPTION
Had an IRC chat with moritz.  He thought my coding wasn't so bad but didn't fit with the surrounding code and suggested this instead.  During the discussion it also came up that recv doesn't support binary very well yet but $socket.read(nnnn) does.  It occurs to me that since HTTP headers often have a Content-length the read solution may be good in the nearish future.
