### PR TITLE
"Die with more informative messages on unuspported protocols"

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -36,6 +36,8 @@ method post (Str $url, %headers = {}, Any $content?) {
 method request_shell (RequestType $rt, Str $url, %headers = {}, Any $content?) {
 
     return unless $url;
+    die "400 URL must be absolute <URL:$url>\n" unless $url ~~ m/^https*\:\/\//;
+    die "501 Protocol scheme 'https' is not supported  <URL:$url>\n" if $url ~~ m/^https\:\/\//; 
 
     my ($scheme, $hostname, $port, $path, $auth) = self.parse_url($url);
 


### PR DESCRIPTION
LWP::Simple currently dies with cryptic error messages when invoked without the "http://" part in the URI. See the following terminal output :

simula67@hades ~ » perl -e "use LWP::Simple; LWP::Simple.getprint('https://www.google.com');"
501 Protocol scheme 'https' is not supported (LWP::Protocol::https not installed) URL:https://www.google.com
simula67@hades ~ » perl -e "use LWP::Simple; LWP::Simple.getprint('www.google.com');" 
400 URL must be absolute URL:www.google.com

simula67@hades ~/repos/perl6/3test » cat test.pl6 
# !/opt/perl6/bin/perl6

use LWP::Simple;
my $url = @*ARGS[0] // "http://www.rakudo.org";
LWP::Simple.getprint($url);

simula67@hades ~/repos/perl6/3test » ./test.pl6 www.google.com
No such method 'lc' for invocant of type 'Any'
  in method scheme at /opt/perl6/lib/parrot/5.9.0/languages/perl6/lib/URI.pm:138
  in method parse_url at /opt/perl6/lib/parrot/5.9.0/languages/perl6/lib/LWP/Simple.pm:297
  in method request_shell at /opt/perl6/lib/parrot/5.9.0/languages/perl6/lib/LWP/Simple.pm:40
  in method get at /opt/perl6/lib/parrot/5.9.0/languages/perl6/lib/LWP/Simple.pm:29
  in method getprint at /opt/perl6/lib/parrot/5.9.0/languages/perl6/lib/LWP/Simple.pm:268
  in block  at ./test.pl6:4
# With the change

simula67@hades ~/repos/perl6/3test » ./test.pl6 www.google.com  
400 URL must be absolute URL:www.google.com

  in method request_shell at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:39
  in method get at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:29
  in method getprint at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:270
  in block  at ./test.pl6:4

simula67@hades ~/repos/perl6/3test » ./test.pl6 https://www.google.com
501 Protocol scheme 'https' is not supported  URL:https://www.google.com

  in method request_shell at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:40
  in method get at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:29
  in method getprint at /home/simula67/repos/perl6-lwp-simple/lib/LWP/Simple.pm:270
  in block  at ./test.pl6:4
