### PR TITLE
Fix chunked transfer-encoding

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -148,6 +148,14 @@ method parse_chunks(Blob $b is rw, IO::Socket::INET $sock) {
 #                say 'inner chunk';
                 $content ~= $b.subbuf($line_end_pos +2, $chunk_len);
                 $line_end_pos = $chunk_start = $line_end_pos + $chunk_len +4;
+
+                if $line_end_pos + 5 > $b.bytes {
+                    # we don't even have enough at the end of our buffer to
+                    # have a minimum valid chunk header. Assume this is
+                    # unfortunate coincidence and read at least enough data for
+                    # a minimal chunk header
+                    $b ~= $sock.read(5);
+                }
             }
             else {
 #                say 'last chunk';


### PR DESCRIPTION
If a chunk header line fell on a buffer boundary just right, parsing
would fail.

Test response data is at https://gist.github.com/retupmoca/11147476 - the initial socket read gets the '0' character, but not any of the '\r\n' stuff after it, so the chunk parsing fails without this patch. I'm not sure what the best way to put this into a .t file is.
