### PR TITLE
the @-sigil followed by a block already is code

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -306,7 +306,7 @@ method parse_url (Str $url) {
     
     return (
         $u.scheme, 
-        $user_info ?? "{$user_info}@{$u.host}" !! $u.host, 
+        $user_info ?? "{$user_info}\@{$u.host}" !! $u.host, 
         $u.port, 
         $path eq '' ?? '/' !! $path,
         $user_info ?? {


### PR DESCRIPTION
This unbreaks LWP::Simple by following a rakudo patch as of yesterday.
