### PR TITLE
t: Either skip a test or run, not both

### DIFF
--- a/t/custom-headers-and-content.t
+++ b/t/custom-headers-and-content.t
@@ -8,11 +8,15 @@ my %headers = ( 'Content-Type' => 'application/json' );
 my $content = '{"method":"echo","params":["Hello from Perl6"],"id":1}';
 my $html    = LWP::Simple.post($host, %headers, $content);
 
-skip("Unable to connect to test site '$host'", 1) unless $html;
-ok(
-    $html.match('Hello from Perl6'),
-    'call to JSON-RPC service using headers and content params'
-);
+if $html {
+    ok(
+        $html.match('Hello from Perl6'),
+        'call to JSON-RPC service using headers and content params'
+    );
+}
+else {
+    skip("Unable to connect to test site '$host'", 1);
+}
 
 done;
 


### PR DESCRIPTION
When $host was down the test crashed, because match method would be
called on an undefined value.

Also as per S24 "The C<skip()> function is called I<instead> of the some
tests (usually because they would die), and emits C<$count> SKIP markers
in the TAP output".
