### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -6,7 +6,7 @@ use MIME::Base64;
 use URI;
 try require IO::Socket::SSL;
 
-class LWP::Simple:auth<cosimo>:ver<0.085>;
+unit class LWP::Simple:auth<cosimo>:ver<0.085>;
 
 our $VERSION = '0.085';
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.