### PR TITLE
Get type.html instead of type-exceptions.html

### DIFF
--- a/t/get-perl6-org.t
+++ b/t/get-perl6-org.t
@@ -12,9 +12,7 @@ ok(
 );
 
 # a page over 64K would be ideal but a bit slow and not really needed yet
-$html = LWP::Simple.get(
-    'http://doc.perl6.org/type-exceptions.html'
-);
+$html = LWP::Simple.get('http://doc.perl6.org/type.html');
 ok(
     $html.match('X::Attribute::Undeclared') &&
         $html.match('</html>'),


### PR DESCRIPTION
It turns out that type.html is more reliable (type-exceptions.html currently
contains no table of exceptions), contains the required string to match, and
has roughly 30K to download (which starts to get close to what is required
for the test).

A better test would be to set up a local web server and fetch the files from there.  This would decouple the test from the internet (and the need for an internet connection) and enable the internet-relevant tests to be run more quickly.  I don't know what a good HTTP server would be in this case, so it's not clear what I should choose.  If you have a preference, I can supply a pull request decoupling the tests from the internet if that is so desired.  Comments as usual are most certainly welcome!