### PR TITLE
fix userinfo/basic auth to be compatible with new URI module and fix …

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,8 +1,8 @@
 {
     "name"        : "LWP::Simple",
-    "version"     : "0.08",
+    "version"     : "0.086",
     "description" : "LWP::Simple quick & dirty implementation for Rakudo Perl 6",
-    "depends"     : [ "MIME::Base64", "URI" ],
+    "depends"     : [ "MIME::Base64", "URI", "URI::Escape" ],
     "provides"    : {
         "LWP::Simple" : "lib/LWP/Simple.pm"
     },

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -4,11 +4,12 @@
 use v6;
 use MIME::Base64;
 use URI;
+use URI::Escape;
 try require IO::Socket::SSL;
 
-unit class LWP::Simple:auth<cosimo>:ver<0.085>;
+unit class LWP::Simple:auth<cosimo>:ver<0.086>;
 
-our $VERSION = '0.085';
+our $VERSION = '0.086';
 
 enum RequestType <GET POST PUT HEAD>;
 
@@ -306,8 +307,7 @@ method getstore (Str $url, Str $filename) {
 method parse_url (Str $url) {
     my URI $u .= new($url);
     my $path = $u.path_query;
-    
-    my $user_info = $u.grammar.parse_result<URI_reference><URI><hier_part><authority><userinfo>;
+    my $user_info = $u.userinfo;
     
     return (
         $u.scheme, 
@@ -316,8 +316,8 @@ method parse_url (Str $url) {
         $path eq '' ?? '/' !! $path,
         $user_info ?? {
             host => $u.host,
-            user => ~ $user_info<likely_userinfo_component>[0],
-            password => ~ $user_info<likely_userinfo_component>[1]
+            user => uri_unescape($user_info.split(':')[0]),
+            password => uri_unescape($user_info.split(':')[1] || '')
         } !! Nil
     );    
 }

--- a/t/basic-auth.t
+++ b/t/basic-auth.t
@@ -7,7 +7,7 @@ use Test;
 
 use LWP::Simple;
 
-plan 8;
+plan 9;
 
 my $basic-auth-url = 'https://ron:Camelia@www.software-path.com/p6-lwp-simple/basic-auth/';
 my @url = LWP::Simple.parse_url($basic-auth-url);
@@ -28,8 +28,7 @@ is(
     'Base64 encoding works'
 );
 
-# # URL seems to have stopped working
-# $basic-auth-url ~~ s/^https/http/;
-# my $html = LWP::Simple.get($basic-auth-url);
-# ok($html.match('protected'), 'Got protected url');
+$basic-auth-url ~~ s/^https/http/;
+my $html = LWP::Simple.get($basic-auth-url);
+ok($html.match('protected'), 'Got protected url');
 


### PR DESCRIPTION
…it better and cleaner anyway

URI module is being updated to kebab case grammar.  When URI is updated it will break old LWP::Simple basic authentication which depended on the grammar (inappropriately).  Perl 5 URI module has userinfo method so I added one to Perl6 URI.  Fix to LWP::Simple uses standard userinfo method instead of depending on URI grammar internals.  To verify, an old test in basic-auth.t has been fixed up and re-enabled.