### PR TITLE
Fix the t/get-unsized.t test

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -146,7 +146,7 @@ method parse_chunks(Blob $b is rw, $sock) {
         if  $line_end_pos +4 <= $b.bytes &&
             $b.subbuf(
                 $chunk_start, $line_end_pos + 2 - $chunk_start
-            ).decode('ascii') ~~ /^(<.xdigit>+)[";"|"\r\n"]/ 
+            ).decode('ascii') ~~ /^(<.xdigit>+)[";"|\r?\n]/ 
         {
 
             # deal with case of chunk_len is 0


### PR DESCRIPTION
After the recent changes that \r\n are handled as unicde there may be come changes needed.  This appears to work.

It also appears that rakudo.org is now chunked, despite the intent of the test but I haven't changed the test.

Fixes #64