### PR TITLE
Replace "as Int" with proper coercion type to fix build

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -204,7 +204,7 @@ method parse_chunks(Blob $b is rw, $sock) {
 }
 
 method make_request (
-    RequestType $rt, $host, $port as Int, $path, %headers, $content?, :$ssl
+    RequestType $rt, $host, Int() $port, $path, %headers, $content?, :$ssl
 ) {
 
     my $headers = self.stringify_headers(%headers);


### PR DESCRIPTION
"as" was removed from rakudo yesterday