### PR TITLE
Allow for moar control over character encoding.

### DIFF
--- a/bin/lwp-download.pl
+++ b/bin/lwp-download.pl
@@ -7,5 +7,6 @@ my $url  = @*ARGS[0] // "http://www.rakudo.org";
 my $file = @*ARGS[1] // "tmpfile-$*PID";
 
 my $lwp = LWP::Simple.new;
+$lwp.force_no_encode = True;
 $lwp.getstore($url, $file);
 

--- a/bin/lwp-get.pl
+++ b/bin/lwp-get.pl
@@ -5,5 +5,7 @@ use LWP::Simple;
 
 my $url = @*ARGS[0] // "http://www.rakudo.org";
 
-LWP::Simple.getprint($url);
+my LWP::Simple $lwp .= new;
+$lwp.force_no_encode = True;
+$lwp.getprint($url);
 

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -14,6 +14,8 @@ our $VERSION = '0.090';
 enum RequestType <GET POST PUT HEAD DELETE>;
 
 has Str $.default_encoding = 'utf-8';
+our $.force_encoding;
+our $.force_no_encode;
 our $.class_default_encoding = 'utf-8';
 
 # these were intended to be constant but that hit pre-compilation issue
@@ -101,7 +103,10 @@ method request_shell (RequestType $rt, Str $url, %headers = {}, Any $content?) {
         when / 20 <[0..9]> / {
 
             # should be fancier about charset decoding application - someday
-            if  $resp_headers<Content-Type> &&
+            if ($.force_encoding) {
+                return $resp_content.decode($.force_encoding);
+            }
+            elsif (not $.force_no_encode) && $resp_headers<Content-Type> &&
                 $resp_headers<Content-Type> ~~
                     /   $<media-type>=[<-[/;]>+]
                         [ <[/]> $<media-subtype>=[<-[;]>+] ]? /  &&


### PR DESCRIPTION
As of now rakudo supports limited set of encodings.
However some websites still use encodings like:

```
$ curl -s -I http://www.google.pl/ | grep charset=
Content-Type: text/html; charset=ISO-8859-2
```

excerpt from https://github.com/rakudo/rakudo/blob/nom/src/core/Rakudo/Internals.pm:

```
my $encodings := nqp::hash(
  # fast mapping for identicals
  'utf8',            'utf8',
  'utf16',           'utf16',
  'utf32',           'utf32',
  'ascii',           'ascii',
  'iso-8859-1',      'iso-8859-1',
  'windows-1252',    'windows-1252',
  # with dash
  'utf-8',           'utf8',
  'utf-16',          'utf16',
  'utf-32',          'utf32',
  # according to http://de.wikipedia.org/wiki/ISO-8859-1
  'iso_8859-1:1987', 'iso-8859-1',
  'iso_8859-1',      'iso-8859-1',
  'iso-ir-100',      'iso-8859-1',
  'latin1',          'iso-8859-1',
  'latin-1',         'iso-8859-1',
  'csisolatin1',     'iso-8859-1',
  'l1',              'iso-8859-1',
  'ibm819',          'iso-8859-1',
  'cp819',           'iso-8859-1',
);
```

It may be useful to:
- tell LWP::Simple not to tamper with encoding (e.g. if you want to pipe the output to other process or print response body to a terminal) 
- force encoding (if you want to further process the response body as a string in your p6 script), so for example in case if the encoding type isn't set and you do know which one it is.
