### PR TITLE
patch to add throwing exception on 4XX/5XX error, instead of returning undef

### DIFF
--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -5,6 +5,7 @@ use v6;
 use MIME::Base64;
 use URI;
 use URI::Escape;
+use X::LWP::Simple::Response;
 try require IO::Socket::SSL;
 
 unit class LWP::Simple:auth<cosimo>:ver<0.090>;
@@ -80,6 +81,14 @@ method request_shell (RequestType $rt, Str $url, %headers = {}, Any $content?) {
         self.make_request($rt, $hostname, $port, $path, %headers, $content, :$ssl);
 
     given $status {
+
+        when / <[4..5]> <[0..9]> <[0..9]> / {
+            X::LWP::Simple::Response.new(
+                status => $status,
+                headers => $resp_headers,
+                content => self!decode-response( :$resp_headers, :$resp_content )
+            ).throw;
+        }
 
         when / 30 <[12]> / {
             my %resp_headers = $resp_headers.hash;

--- a/lib/X/LWP/Simple/Response.pm
+++ b/lib/X/LWP/Simple/Response.pm
@@ -1,0 +1,13 @@
+unit class X::LWP::Simple::Response is Exception;
+
+has Str $.status is rw;
+has Hash $.headers is rw;
+has Str $.content is rw;
+
+method Str() {
+    return ~self.status;
+}
+
+method gist() {
+    return self.Str;
+}

--- a/t/get-404.t
+++ b/t/get-404.t
@@ -1,0 +1,13 @@
+use v6;
+use Test;
+
+use LWP::Simple;
+
+plan 1;
+
+# these tests will fail if this url stops returning 404 response
+throws-like {
+    LWP::Simple.get('http://www.perl6.org/404');
+},
+X::LWP::Simple::Response,
+status => rx:i:s/404 Not Found/;


### PR DESCRIPTION
My reason for wanting this is that JSON::RPC::Client chokes on an undef response.
Getting some more specific info on the failure will help JSON::RPC::Client deal with errors better.
